### PR TITLE
Use ci boilerplate from aries-vcx project. Prevent prereleasing every build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,8 +35,7 @@ jobs:
         run: |
           set -x
 
-          if [[ -z "$GITHUB_HEAD_REF" ]] # is set only if pipeline run is triggered as pull request
-          then
+          if [[ -z "$GITHUB_HEAD_REF" ]]; then # is set only if pipeline run is triggered as pull request
             BRANCH_NAME="${GITHUB_REF#refs/heads/}"
             echo "Setting BRANCH_NAME=$BRANCH_NAME because this pipeline is run as Push"
           else
@@ -46,14 +45,14 @@ jobs:
 
           BRANCH_NAME=`echo $BRANCH_NAME | sed "s/[^[:alnum:]-]//g" | tr '[:upper:]' '[:lower:]'` # lowercase, only alphanumeric and dash
 
-          if [[ "${{ github.event_name }}" == "pull_request" ]]
-          then
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "PR Labels: ${{ toJson(github.event.pull_request.labels.*.name) }}"
+
             REPO_HEAD="${{ github.event.pull_request.head.repo.full_name }}" # source repository
             REPO_BASE="${{ github.event.pull_request.head.base.full_name }}" # target repository
             echo "This is pull request from $REPO_HEAD to $REPO_BASE"
 
-            if [[ "$REPO_HEAD" == "${{ github.repository }}" ]]
-            then
+            if [[ "$REPO_HEAD" == "${{ github.repository }}" ]]; then
               echo "This CI run is PR from non-forked repository."
               IS_FORK="false";
             else
@@ -66,36 +65,30 @@ jobs:
           fi;
 
           REPO_VERSION_MOST_RECENT=$(git describe --tags --always --abbrev=0)
-          export REPO_VERSION_DESIRED=`bash ./get-version.sh`
+          REPO_VERSION_DESIRED=$(cargo pkgid --manifest-path libvcx/Cargo.toml | cut -d# -f2 | cut -d: -f2)
           echo "Highest released version was: $REPO_VERSION_MOST_RECENT, desired version (specified in libvcx/Cargo.toml) is $REPO_VERSION_DESIRED"
 
           RELEASE="false"
           PRERELEASE="false"
-          if [[ "$IS_FORK" == "false" ]]
-          then
-            if [[ "$REPO_VERSION_DESIRED" != "$REPO_VERSION_MOST_RECENT" ]]
-            then
-              if [[ "$BRANCH_NAME" == "master" ]]
-              then
+
+          if [[ "$IS_FORK" == "false" ]]; then
+            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+              if [[ "${{ contains(github.event.pull_request.labels.*.name, 'pre-release') }}" == "true" ]]; then
+                PRERELEASE="true"
+              fi;
+            elif [[ "${{ github.event_name }}" == "push" ]]; then
+              if [[ "$BRANCH_NAME" == "master" && "$REPO_VERSION_DESIRED" != "$REPO_VERSION_MOST_RECENT" ]]; then
                 PUBLISH_VERSION="$REPO_VERSION_DESIRED"
                 RELEASE="true"
                 echo "This is push to master, and version was bumped from $REPO_VERSION_MOST_RECENT to $REPO_VERSION_DESIRED. Will publish a release of $REPO_VERSION_DESIRED."
-              elif [[ "${{ github.event_name }}" == "pull_request" ]]
-              then
-                PUBLISH_VERSION="$REPO_VERSION_MOST_RECENT-${{ github.run_number }}"
-                PRERELEASE="true"
-                echo "This is push to a non-master branch on a PR, and version was bumped from $REPO_VERSION_MOST_RECENT to $REPO_VERSION_DESIRED. Will publish a pre-release of $REPO_VERSION_DESIRED."
-              fi;
-            else
-              PUBLISH_VERSION="$REPO_VERSION_MOST_RECENT-$BRANCH_NAME-${{ github.run_number }}"
-              if [[ "${{ github.event_name }}" == "pull_request" && ${{ contains(github.event.pull_request.labels.*.name, 'pre-release') }} ]]
-              then
-                PRERELEASE="true"
-                echo "This is a PR with `pre-release` label set. Will publish and prerelease version: $PUBLISH_VERSION."
-              else
-                echo "This is not push to master. Will be publishing version: $PUBLISH_VERSION."
               fi;
             fi;
+
+            if [[ -z "$PUBLISH_VERSION" ]]; then
+              PUBLISH_VERSION="$REPO_VERSION_MOST_RECENT-$BRANCH_NAME-${{ github.run_number }}"
+            fi;
+
+            echo "CI will publish artifacts at version: $PUBLISH_VERSION"
           else
             echo "This PR is from fork, nothing will be published because the CI wouldn't be able to access repo secrets to perform publish."
             PUBLISH_VERSION=""


### PR DESCRIPTION
Aries-VCX is using new version of initial CI setup boilerplate. In previous version of vcxagency node, CI was making pre-releases from every CI run on PRs