### PR TITLE
Improve logging, various enhancements

### DIFF
--- a/vcxagency-client/src/encryption/a2a.js
+++ b/vcxagency-client/src/encryption/a2a.js
@@ -19,36 +19,21 @@
 const { unpack } = require('easy-indysdk')
 
 async function parseAnoncrypted (walletHandle, buffer) {
-  const agencyMode = '2.0'
-  if (agencyMode === '1.0') {
-    throw Error('Not implemented')
-  } else {
-    const { message } = await unpack(walletHandle, buffer)
-    return JSON.parse(message)
-  }
+  const { message } = await unpack(walletHandle, buffer)
+  return JSON.parse(message)
 }
 
 async function parseAuthcrypted (walletHandle, buffer) {
-  const agencyMode = '2.0'
-  if (agencyMode === '1.0') {
-    throw Error('Not implemented')
-  } else {
-    const { message, sender_verkey: senderVerkey } = await unpack(walletHandle, buffer)
-    if (!senderVerkey) {
-      throw Error('Authcrypted message was expected but sender_verkey is unknown after unpack.')
-    }
-    return { message: JSON.parse(message), senderVerkey }
+  const { message, sender_verkey: senderVerkey } = await unpack(walletHandle, buffer)
+  if (!senderVerkey) {
+    throw Error('Authcrypted message was expected but sender_verkey is unknown after unpack.')
   }
+  return { message: JSON.parse(message), senderVerkey }
 }
 
 async function tryParseAuthcrypted (walletHandle, buffer) {
-  const agencyMode = '2.0'
-  if (agencyMode === '1.0') {
-    throw Error('Not implemented')
-  } else {
-    const { message, sender_verkey: senderVerkey } = await unpack(walletHandle, buffer)
-    return { message: JSON.parse(message), senderVerkey }
-  }
+  const { message, sender_verkey: senderVerkey } = await unpack(walletHandle, buffer)
+  return { message: JSON.parse(message), senderVerkey }
 }
 
 module.exports = {

--- a/vcxagency-client/test/e2e/ea/longpoll-disabled.spec.js
+++ b/vcxagency-client/test/e2e/ea/longpoll-disabled.spec.js
@@ -80,6 +80,6 @@ describe('longpoll', () => {
       thrown = err
     }
     expect(thrown.response.status).toBe(409)
-    expect(thrown.response.data.error.message).toBe('Feature is not enabled.')
+    expect(thrown.response.data.errorTraceId).toBeDefined()
   })
 })

--- a/vcxagency-node/src/api/api-messaging.js
+++ b/vcxagency-node/src/api/api-messaging.js
@@ -21,10 +21,13 @@ const { asyncHandler } = require('./middleware')
 module.exports = function (expressRouter, forwardAgent) {
   expressRouter.post('/',
     asyncHandler(async function (req, res) {
-      let resStatus = 200
       const responseData = await forwardAgent.handleIncomingMessage(req.body)
-      if (responseData.errorMsg) resStatus = 500
+      const { errorTraceId } = responseData
+      if (errorTraceId) {
+        res.set('content-type', 'application/json')
+        return res.status(500).send({ errorTraceId })
+      }
       res.set('content-type', 'application/ssi-agent-wire')
-      res.status(resStatus).send(responseData)
+      res.status(200).send(responseData)
     }))
 }

--- a/vcxagency-node/src/configuration/app-config-loader.js
+++ b/vcxagency-node/src/configuration/app-config-loader.js
@@ -33,6 +33,7 @@ function buildAppConfigFromEnvVariables () {
     LOG_LEVEL: process.env.LOG_LEVEL || 'info',
     LOG_ENABLE_INDYSDK: process.env.LOG_ENABLE_INDYSDK || 'false',
     LOG_JSON_TO_CONSOLE: process.env.LOG_JSON_TO_CONSOLE,
+    LOG_HEALTH_REQUESTS: process.env.LOG_HEALTH_REQUESTS,
 
     SERVER_PORT: process.env.SERVER_PORT,
     SERVER_HOSTNAME: process.env.SERVER_HOSTNAME,

--- a/vcxagency-node/src/configuration/app-config.js
+++ b/vcxagency-node/src/configuration/app-config.js
@@ -42,6 +42,8 @@ const configValidation = Joi.object().keys({
   LOG_LEVEL: Joi.string().valid('silly', 'debug', 'info', 'warn', 'error'),
   LOG_ENABLE_INDYSDK: Joi.string().valid('true', 'false'),
   LOG_JSON_TO_CONSOLE: Joi.string().valid('true', 'false'),
+  LOG_HEALTH_REQUESTS: Joi.string().valid('true', 'false').default('false'),
+
   SERVER_PORT: Joi.number().integer().min(1025).max(65535).required(),
   SERVER_HOSTNAME: Joi.string().default('0.0.0.0'),
   SERVER_MAX_REQUEST_SIZE_KB: Joi.number().integer().min(1).max(MB_AS_KB * 10).default(512),

--- a/vcxagency-node/src/logging/logger-builder.js
+++ b/vcxagency-node/src/logging/logger-builder.js
@@ -57,7 +57,7 @@ const mainLoggerName = 'main'
 
 const formatter = process.env.LOG_JSON_TO_CONSOLE === 'true' ? jsonFormatter : prettyFormatter
 const logLevel = process.env.LOG_LEVEL ? process.env.LOG_LEVEL : 'info'
-createConsoleLogger(mainLoggerName, formatter, logLevel, process.env.SILENT_WINSTON)
+createConsoleLogger(mainLoggerName, formatter, logLevel, process.env.SILENT_WINSTON === 'true')
 
 module.exports = function (fullPath) {
   return addChildLogger(mainLoggerName, fullPath)

--- a/vcxagency-node/src/logging/logger-builder.js
+++ b/vcxagency-node/src/logging/logger-builder.js
@@ -18,7 +18,7 @@
 
 const winston = require('winston')
 const path = require('path')
-const { characterTruncater, jsonFormatter, tryAddRequestId } = require('./logger-common')
+const { jsonFormatter, tryAddRequestId } = require('./logger-common')
 
 const prettyFormatter = winston.format.combine(
   winston.format.colorize({ all: true }),
@@ -36,7 +36,6 @@ function createConsoleLogger (mainLoggerName, formatter, logLevel, makeItSilent 
         silent: makeItSilent,
         level: logLevel,
         format: winston.format.combine(
-          characterTruncater(5000),
           winston.format.timestamp({
             format: 'YYYY-MM-DD HH:mm:ss.SSS'
           }),

--- a/vcxagency-node/src/logging/logger-common.js
+++ b/vcxagency-node/src/logging/logger-common.js
@@ -26,26 +26,11 @@ const tryAddRequestId = winston.format.combine(
   })
 )
 
-const characterTruncater = lengthLimit => {
-  return winston.format.combine(
-    winston.format.printf(info => {
-      const m = info.message
-      if (typeof m === 'string') {
-        const tailLength = Math.floor(lengthLimit / 2)
-        const filler = `[${Math.floor(m.length - lengthLimit)} chars]`
-        info.message = (m.length < lengthLimit) ? m : (m.substring(0, tailLength) + filler + m.substring(m.length - tailLength, m.length))
-      }
-      return info
-    })
-  )
-}
-
 const jsonFormatter = winston.format.combine(
   winston.format.printf(
-    info => JSON.stringify(info).replace(/\\n/g, '\\n').replace(/\\t/g, '\\t')
+    info => JSON.stringify(info)
   )
 )
 
-module.exports.characterTruncater = characterTruncater
 module.exports.jsonFormatter = jsonFormatter
 module.exports.tryAddRequestId = tryAddRequestId

--- a/vcxagency-node/src/service/entities/agent-connection/agent-connection.js
+++ b/vcxagency-node/src/service/entities/agent-connection/agent-connection.js
@@ -163,7 +163,6 @@ async function buildAgentConnectionAO (entityRecord, serviceWallets, serviceStor
 
   async function trySendNotification (msgUid) {
     const webhookUrl = await serviceStorage.getAgentWebhook(agentDid)
-    logger.info(`${whoami} Received aries message and resolved webhook ${webhookUrl}`)
     if (webhookUrl) {
       sendNotification(webhookUrl, msgUid, userPairwiseDid)
         .catch(err => {
@@ -180,7 +179,9 @@ async function buildAgentConnectionAO (entityRecord, serviceWallets, serviceStor
   async function _handleAriesFwd (msgObject) {
     const msgUid = uuid.v4()
     const statusCode = 'MS-103'
+    logger.info(`${whoami} Received new Aries message msgUid=${msgUid}.`)
     await serviceStorage.storeMessage(agentDid, agentConnectionDid, msgUid, statusCode, msgObject.msg)
+    logger.info(`${whoami} Stored message msgUid=${msgUid}.`)
     serviceNewMessages.flagNewMessage(agentDid)
       .catch(err => {
         logger.error(`${whoami} Failed to set new-message flag, agentDid=${agentDid}, msgUid=${msgUid} Error: ${err.stack}`)

--- a/vcxagency-node/src/service/entities/agent-connection/agent-connection.js
+++ b/vcxagency-node/src/service/entities/agent-connection/agent-connection.js
@@ -163,15 +163,15 @@ async function buildAgentConnectionAO (entityRecord, serviceWallets, serviceStor
 
   async function trySendNotification (msgUid) {
     const webhookUrl = await serviceStorage.getAgentWebhook(agentDid)
-    logger.info(`Agent ${agentDid} received aries message and resolved webhook ${webhookUrl}`)
+    logger.info(`${whoami} Received aries message and resolved webhook ${webhookUrl}`)
     if (webhookUrl) {
       sendNotification(webhookUrl, msgUid, userPairwiseDid)
         .catch(err => {
           if (err.message.includes('timeout')) {
-            logger.debug(`Webhook url didn't respond quickly enough, err=${err.stack}`)
+            logger.debug(`${whoami} Webhook url didn't respond quickly enough, err=${err.stack}`)
             // we don't log timeout errors, webhook integrators are expected to respond quickly
           } else {
-            logger.warn(`Error sending webhook notification, err=${err.stack}`)
+            logger.warn(`${whoami} Error sending webhook notification, err=${err.stack}`)
           }
         })
     }
@@ -183,11 +183,11 @@ async function buildAgentConnectionAO (entityRecord, serviceWallets, serviceStor
     await serviceStorage.storeMessage(agentDid, agentConnectionDid, msgUid, statusCode, msgObject.msg)
     serviceNewMessages.flagNewMessage(agentDid)
       .catch(err => {
-        logger.error(`Failed to set new-message flag, agentDid=${agentDid}, agentConnectionDid=${agentConnectionDid}, msgUid=${msgUid} Error: ${err.stack}`)
+        logger.error(`${whoami} Failed to set new-message flag, agentDid=${agentDid}, msgUid=${msgUid} Error: ${err.stack}`)
       })
     trySendNotification(msgUid)
       .catch(err => {
-        logger.error(`Failed trying to send new-message notification, agentDid=${agentDid}, agentConnectionDid=${agentConnectionDid}, msgUid=${msgUid} Error: ${err.stack}`)
+        logger.error(`${whoami} Failed trying to send webhook notification, agentDid=${agentDid}, msgUid=${msgUid} Error: ${err.stack}`)
       })
   }
 

--- a/vcxagency-node/src/service/entities/agent/agent.js
+++ b/vcxagency-node/src/service/entities/agent/agent.js
@@ -128,8 +128,18 @@ async function buildAgentAO (entityRecord, serviceWallets, serviceStorage, route
     } else {
       logger.info(`${whoami} Handling message ${JSON.stringify(msgObject)}`)
       const responseObject = await _handleAuthorizedAgentMessage(msgObject, senderVerkey)
-      logger.debug(`${whoami} Sending response: ${JSON.stringify(responseObject)}`)
+      _logResponseObject(responseObject)
       return { response: responseObject, wasEncrypted: false }
+    }
+  }
+
+  function _logResponseObject (responseObject) {
+    const msgType = responseObject['@type']
+    if (msgType === MSGTYPE_GET_MSGS_BY_CONNS) {
+      const msgCount = responseObject.msgs.length
+      logger.info(`${whoami} Sending response of type ${msgType}, retrieved ${msgCount} messages.`)
+    } else {
+      logger.info(`${whoami} Sending response: ${JSON.stringify(responseObject)}`)
     }
   }
 

--- a/vcxagency-node/src/service/entities/fwa/entity-fwa.js
+++ b/vcxagency-node/src/service/entities/fwa/entity-fwa.js
@@ -28,9 +28,9 @@ const { pack, indyCreateAndStoreMyDid, indyDidExists, indyKeyForLocalDid } = req
 const logger = require('../../../logging/logger-builder')(__filename)
 const util = require('util')
 const { objectToBuffer } = require('../../util')
-const uuid = require('uuid')
 const { createAgentData } = require('../agent/agent')
 const sleep = require('sleep-promise')
+const httpContext = require('express-http-context')
 
 const FWA_KDF = 'ARGON2I_MOD'
 
@@ -133,7 +133,7 @@ async function buildForwardAgent (serviceIndyWallets, serviceStorage, agencyWall
       wh = await serviceIndyWallets.getWalletHandle(agencyWalletName, agencyWalletKey, FWA_KDF)
       logger.debug(`${whoami} Retrieved wallet handle for fwa wallet, wh=${wh}`)
     } catch (err) {
-      const errorTraceId = uuid.v4()
+      const errorTraceId = httpContext.get('reqId')
       const errorMsg = `${whoami} Error accessing FWA wallet, agencyWalletName=${agencyWalletName}, error=${err.stack}`
       logger.error(errorMsg)
       return { errorTraceId, errorMsg }
@@ -149,13 +149,13 @@ async function buildForwardAgent (serviceIndyWallets, serviceStorage, agencyWall
         logger.info(`${whoami} Received message of msgType=${msgType}`)
         return await processMsgAriesFwd(message)
       } else {
-        const errorTraceId = uuid.v4()
+        const errorTraceId = httpContext.get('reqId')
         const errorMsg = `${whoami} Received message of unsupported msgType=${msgType}, errorTraceId=${errorTraceId}`
         logger.error(errorMsg)
         return { errorTraceId, errorMsg }
       }
-    } catch (err) { /// todo : in tests we relied that we'd return errorMsg from here
-      const errorTraceId = uuid.v4()
+    } catch (err) {
+      const errorTraceId = httpContext.get('reqId')
       const errorMsg = `${whoami} Error processing received message, errorTraceId=${errorTraceId}, error=${err.stack}`
       logger.error(errorMsg)
       return { errorTraceId, errorMsg }

--- a/vcxagency-node/src/service/notifications/webhook.js
+++ b/vcxagency-node/src/service/notifications/webhook.js
@@ -16,8 +16,8 @@
 
 'use strict'
 
-const http = require("http")
-const https = require("https")
+const http = require('http')
+const https = require('https')
 const axios = require('axios')
 const uuid = require('uuid')
 const httpContext = require('express-http-context')

--- a/vcxagency-node/src/service/notifications/webhook.js
+++ b/vcxagency-node/src/service/notifications/webhook.js
@@ -16,22 +16,36 @@
 
 'use strict'
 
+const http = require("http")
+const https = require("https")
 const axios = require('axios')
 const uuid = require('uuid')
 const httpContext = require('express-http-context')
 const logger = require('../../logging/logger-builder')(__filename)
 
-async function sendNotification (webhookUrl, msgUid, msgStatusCode, notificationId, pwDid) {
-  const notification = {
-    msgUid, msgType: 'aries', theirPwDid: '', msgStatusCode, notificationId, pwDid
-  }
+// default timeout is low; webhook integrators should reply quickly,
+// otherwise agency might end up having too many connections open
+const WEBHOOK_RESPONSE_TIMEOUT_MS = process.env.WEBHOOK_RESPONSE_TIMEOUT_MS || 5
+const httpAgent = new http.Agent({ keepAlive: true })
+const httpsAgent = new https.Agent({ keepAlive: true })
+
+const axiosInstance = axios.create({
+  httpAgent,
+  httpsAgent
+})
+
+async function sendNotification (webhookUrl, msgUid, pwDid) {
+  const notification = { msgUid, pwDid }
   const headers = {}
   const requestId = httpContext.get('reqId')
   headers['X-Request-ID'] = requestId || uuid.v4()
   if (!requestId) {
     logger.error(`Sending webhook notification but reqId was not found in httpContext. Setting X-Request-ID to '${headers['X-Request-ID']}'.`)
   }
-  await axios.post(webhookUrl, notification, { headers })
+  await axiosInstance.post(webhookUrl, notification, {
+    headers,
+    timeout: WEBHOOK_RESPONSE_TIMEOUT_MS
+  })
 }
 
 module.exports = { sendNotification }

--- a/vcxagency-node/src/service/notifications/webhook.js
+++ b/vcxagency-node/src/service/notifications/webhook.js
@@ -26,13 +26,10 @@ async function sendNotification (webhookUrl, msgUid, msgStatusCode, notification
     msgUid, msgType: 'aries', theirPwDid: '', msgStatusCode, notificationId, pwDid
   }
   const headers = {}
-  const xRequestId = httpContext.get('reqId')
-  if (xRequestId) {
-    headers['X-Request-ID'] = xRequestId
-  } else {
-    const xRequestId = uuid.v4()
-    headers['X-Request-ID'] = xRequestId
-    logger.error(`Sending webhook notification but reqId was not found in httpContext. Setting X-Request-ID to '${xRequestId}'.`)
+  const requestId = httpContext.get('reqId')
+  headers['X-Request-ID'] = requestId || uuid.v4()
+  if (!requestId) {
+    logger.error(`Sending webhook notification but reqId was not found in httpContext. Setting X-Request-ID to '${headers['X-Request-ID']}'.`)
   }
   await axios.post(webhookUrl, notification, { headers })
 }

--- a/vcxagency-node/src/service/state/service-indy-wallets.js
+++ b/vcxagency-node/src/service/state/service-indy-wallets.js
@@ -17,6 +17,7 @@
 'use strict'
 
 const { indyGenerateWalletKey, indyCreateAndStoreMyDid, indyCreateWallet, indyAssureWallet, indyOpenWallet } = require('easy-indysdk')
+const logger = require('../../logging/logger-builder')(__filename)
 
 /**
  * Creates object for managing indy wallet handles. As a consumer of this interface you should not preserve wallet handles
@@ -25,6 +26,7 @@ const { indyGenerateWalletKey, indyCreateAndStoreMyDid, indyCreateWallet, indyAs
  */
 async function createServiceIndyWallets (storageType = 'default', storageConfig, storageCredentials) {
   const openWalletHandlesCache = {}
+  let cacheHandlesCount = 0
 
   async function assureWallet (walletName, walletKey, keyDerivationMethod) {
     await indyAssureWallet(walletName, walletKey, keyDerivationMethod, storageType, storageConfig, storageCredentials)
@@ -35,16 +37,22 @@ async function createServiceIndyWallets (storageType = 'default', storageConfig,
   on long inactivity, deletion of agent and its wallet etc.)
    */
   async function getWalletHandle (walletName, walletKey, keyDerivationMethod) {
+    logger.info(`Getting wallet handle for wallet ${walletName}, whCache contains ${cacheHandlesCount} handles.`)
     let wh = openWalletHandlesCache[walletName]
     if (wh) {
       return wh
+    } else {
+      logger.info(`Opening wallet ${walletName}`)
+      wh = await indyOpenWallet(walletName, walletKey, keyDerivationMethod, storageType, storageConfig, storageCredentials)
+      openWalletHandlesCache[walletName] = wh
+      cacheHandlesCount += 1
+      logger.info(`Opened wallet ${walletName}, wh=${wh}`)
+      return wh
     }
-    wh = await indyOpenWallet(walletName, walletKey, keyDerivationMethod, storageType, storageConfig, storageCredentials)
-    openWalletHandlesCache[walletName] = wh
-    return wh
   }
 
   async function createNewRawWalletForEntity (walletName) {
+    logger.info(`Creating new entity wallet, walletName=${walletName}`)
     const keyDerivationMethod = 'RAW'
     const walletKey = await indyGenerateWalletKey()
     await indyCreateWallet(walletName, walletKey, keyDerivationMethod, storageType, storageConfig, storageCredentials)

--- a/vcxagency-node/src/service/state/service-indy-wallets.js
+++ b/vcxagency-node/src/service/state/service-indy-wallets.js
@@ -37,7 +37,6 @@ async function createServiceIndyWallets (storageType = 'default', storageConfig,
   on long inactivity, deletion of agent and its wallet etc.)
    */
   async function getWalletHandle (walletName, walletKey, keyDerivationMethod) {
-    logger.info(`Getting wallet handle for wallet ${walletName}, whCache contains ${cacheHandlesCount} handles.`)
     let wh = openWalletHandlesCache[walletName]
     if (wh) {
       return wh
@@ -46,7 +45,7 @@ async function createServiceIndyWallets (storageType = 'default', storageConfig,
       wh = await indyOpenWallet(walletName, walletKey, keyDerivationMethod, storageType, storageConfig, storageCredentials)
       openWalletHandlesCache[walletName] = wh
       cacheHandlesCount += 1
-      logger.info(`Opened wallet ${walletName}, wh=${wh}`)
+      logger.info(`Opened wallet ${walletName}, wh=${wh}, cacheHandlesCount=${cacheHandlesCount}`)
       return wh
     }
   }

--- a/vcxagency-node/test/unit/messaging/aries-msgs.spec.js
+++ b/vcxagency-node/test/unit/messaging/aries-msgs.spec.js
@@ -208,7 +208,7 @@ describe('onboarding', () => {
       // wait a bit and check alice has received notification about received message on her dummy server
       await sleep(1000)
       expect(serverReceivedNotification.msgUid).toBeDefined()
-      expect(serverReceivedNotificationHeaders['X-Request-ID']).toBeDefined()
+      expect(serverReceivedNotificationHeaders['x-request-id']).toBeDefined()
       expect(serverReceivedNotification.pwDid).toBe(aliceToBobDid)
     } finally {
       if (testServer) {
@@ -256,7 +256,7 @@ describe('onboarding', () => {
       // wait a bit and check alice has received notification about received message on her dummy server
       await sleep(1000)
       expect(serverReceivedNotification.msgUid).toBeDefined()
-      expect(serverReceivedNotificationHeaders['X-Request-ID']).toBeDefined()
+      expect(serverReceivedNotificationHeaders['x-request-id']).toBeDefined()
       expect(serverReceivedNotification.pwDid).toBe(aliceToBobDid)
     } finally {
       if (testServer) {

--- a/vcxagency-node/test/unit/messaging/aries-msgs.spec.js
+++ b/vcxagency-node/test/unit/messaging/aries-msgs.spec.js
@@ -176,6 +176,7 @@ describe('onboarding', () => {
     try {
       // set up dummy server for alice to receive notifications from agency
       let serverReceivedNotification = {}
+      let serverReceivedNotificationHeaders = {}
       const TEST_SERVER_PORT = 49412
 
       const appNotifications = express()
@@ -183,6 +184,7 @@ describe('onboarding', () => {
       appNotifications.post('/notifications',
         async function (req, res) {
           serverReceivedNotification = req.body
+          serverReceivedNotificationHeaders = req.headers
           res.status(200).send()
         })
       testServer = appNotifications.listen(TEST_SERVER_PORT)
@@ -206,7 +208,7 @@ describe('onboarding', () => {
       // wait a bit and check alice has received notification about received message on her dummy server
       await sleep(1000)
       expect(serverReceivedNotification.msgUid).toBeDefined()
-      expect(serverReceivedNotification.notificationId).toBeDefined()
+      expect(serverReceivedNotificationHeaders['X-Request-ID']).toBeDefined()
       expect(serverReceivedNotification.pwDid).toBe(aliceToBobDid)
     } finally {
       if (testServer) {
@@ -220,6 +222,7 @@ describe('onboarding', () => {
     try {
       // set up dummy server for alice to receive notifications from agency
       let serverReceivedNotification = {}
+      let serverReceivedNotificationHeaders = {}
       const TEST_SERVER_PORT = 49412
 
       const appNotifications = express()
@@ -227,6 +230,7 @@ describe('onboarding', () => {
       appNotifications.post('/notifications',
         async function (req, res) {
           serverReceivedNotification = req.body
+          serverReceivedNotificationHeaders = req.headers
           res.status(200).send()
         })
       testServer = appNotifications.listen(TEST_SERVER_PORT)
@@ -252,7 +256,7 @@ describe('onboarding', () => {
       // wait a bit and check alice has received notification about received message on her dummy server
       await sleep(1000)
       expect(serverReceivedNotification.msgUid).toBeDefined()
-      expect(serverReceivedNotification.notificationId).toBeDefined()
+      expect(serverReceivedNotificationHeaders['X-Request-ID']).toBeDefined()
       expect(serverReceivedNotification.pwDid).toBe(aliceToBobDid)
     } finally {
       if (testServer) {

--- a/vcxagency-node/test/unit/messaging/aries-msgs.spec.js
+++ b/vcxagency-node/test/unit/messaging/aries-msgs.spec.js
@@ -223,7 +223,7 @@ describe('onboarding', () => {
       // set up dummy server for alice to receive notifications from agency
       let serverReceivedNotification = {}
       let serverReceivedNotificationHeaders = {}
-      const TEST_SERVER_PORT = 49412
+      const TEST_SERVER_PORT = 49413
 
       const appNotifications = express()
       appNotifications.use(bodyParser.json())


### PR DESCRIPTION
- Only return `errorTraceId` if error occurs while processing aries message
- Add config option `LOG_HEALTH_REQUESTS` to opt-into logging all express requests including health queries
- Optimize logging middleware
- Improve logging messages, use more appropriate log levels
- Improve error handling and logging in case of errors
- Bugfix: include `reqId` from httpContext with each log message tied to an incoming request
- Improvment: propagate `reqId` from httpContext to `X-Request-ID` header in requests made to webhook URL.
- Minor clean ups, dead code removal
- Axios client for webhook calls use http(s)Agent with `keepAlive: true` to enable tcp socket pooling


Signed-off-by: Patrik Stas <patrik.stas@absa.africa>