### PR TITLE
Optimize message status updates

### DIFF
--- a/dbutils/migrations_scheme_application/20220407134403-unique-uid-constrain.js
+++ b/dbutils/migrations_scheme_application/20220407134403-unique-uid-constrain.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20220407134403-unique-uid-constrain-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20220407134403-unique-uid-constrain-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/dbutils/migrations_scheme_application/sqls/20220407134403-unique-uid-constrain-down.sql
+++ b/dbutils/migrations_scheme_application/sqls/20220407134403-unique-uid-constrain-down.sql
@@ -1,0 +1,1 @@
+/* Replace with your SQL commands */

--- a/dbutils/migrations_scheme_application/sqls/20220407134403-unique-uid-constrain-up.sql
+++ b/dbutils/migrations_scheme_application/sqls/20220407134403-unique-uid-constrain-up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE messages ADD CONSTRAINT unique_uid UNIQUE (uid)

--- a/vcxagency-client/src/messaging/client2agency/msgs-agent.js
+++ b/vcxagency-client/src/messaging/client2agency/msgs-agent.js
@@ -77,9 +77,7 @@ function buildMsgVcxV2UpdateMsgStatusByConns (statusCode, uidsByConns) {
 
 function buildMsgVcxV2MsgStatusUpdatedByConns (failedUidsByConns, updatedUidsByConns) {
   const msg = {
-    '@type': MSGTYPE_MSG_STATUS_UPDATED_BY_CONNS,
-    failed: failedUidsByConns, // [{"pairwiseDID":"Fp4eVWcjyRawjNWgnJmJWD","uids":["aBcDeF1234"]}]}
-    updatedUidsByConns // example: [{"pairwiseDID":"Fp4eVWcjyRawjNWgnJmJWD","uids":["b7vh36XiTe"]}]}
+    '@type': MSGTYPE_MSG_STATUS_UPDATED_BY_CONNS
   }
   return msg
 }

--- a/vcxagency-client/src/messaging/client2agency/msgs-agent.js
+++ b/vcxagency-client/src/messaging/client2agency/msgs-agent.js
@@ -75,9 +75,11 @@ function buildMsgVcxV2UpdateMsgStatusByConns (statusCode, uidsByConns) {
   return msg
 }
 
-function buildMsgVcxV2MsgStatusUpdatedByConns (failedUidsByConns, updatedUidsByConns) {
+function buildMsgVcxV2MsgStatusUpdatedByConns () {
   const msg = {
-    '@type': MSGTYPE_MSG_STATUS_UPDATED_BY_CONNS
+    '@type': MSGTYPE_MSG_STATUS_UPDATED_BY_CONNS,
+    failed: [],
+    updatedUidsByConns: []
   }
   return msg
 }

--- a/vcxagency-node/src/service/storage/storage.js
+++ b/vcxagency-node/src/service/storage/storage.js
@@ -287,32 +287,6 @@ async function createDataStorage (appStorageConfig) {
   }
 
   /**
-   * For Agent's connection, converts "User Pairwise Did" into "Agent Connection Did"
-   * @param {string} agentDid - DID of an Agent owning connection
-   * @param {string} pwDid - "User Pairwise DID" associated with the connection
-   */
-  async function pwDidToAconnDid (agentDid, pwDid) {
-    const res = await aconnLinkPairsByPwDids(agentDid, [pwDid])
-    if (res.length === 0) {
-      return undefined
-    }
-    return res[0].agentConnDid
-  }
-
-  /**
-   * For Agent's connection, converts "Agent Connection Did" into "User Pairwise Did"
-   * @param {string} agentDid - DID of an Agent owning connection
-   * @param {string} aconnDid - "User Pairwise DID" associated with the connection
-   */
-  async function aconnDidToPwDid (agentDid, aconnDid) {
-    const res = await aconnLinkPairsByAconnDids(agentDid, [aconnDid])
-    if (res.length === 0) {
-      return undefined
-    }
-    return res[0].userPwDid
-  }
-
-  /**
    * Returns list of tuples ( "Agent Connection Did", "User pairwise Did"), each representing one connection.
    * @param {string} agentDid - DID of an Agent owning the connection.
    * @param {array} filterUserPwDids - Filters records by "User Pairwise DIDs". Empty array disables filter.
@@ -372,8 +346,6 @@ async function createDataStorage (appStorageConfig) {
     linkAgentToItsConnection,
     aconnLinkPairsByPwDids,
     aconnLinkPairsByAconnDids,
-    pwDidToAconnDid,
-    aconnDidToPwDid,
 
     setHasNewMessage,
     getHasNewMessage,

--- a/vcxagency-node/test/unit/messaging/aconn-msgs.spec.js
+++ b/vcxagency-node/test/unit/messaging/aconn-msgs.spec.js
@@ -58,6 +58,18 @@ let sendToAgency
 let tmpDbData
 let tmpDbWallet
 
+let msg1Id
+let msg2Id
+let msg3Id
+let msg4Id
+
+function regenerateUuids () {
+  msg1Id = uuid.v4()
+  msg2Id = uuid.v4()
+  msg3Id = uuid.v4()
+  msg4Id = uuid.v4()
+}
+
 beforeAll(async () => {
   try {
     jest.setTimeout(1000 * 120)
@@ -94,6 +106,7 @@ afterAll(async () => {
 })
 
 beforeEach(async () => {
+  regenerateUuids()
   {
     agencyUserWalletKey = await indyGenerateWalletKey()
     agencyUserWalletName = `unit-test-${uuid.v4()}`
@@ -131,11 +144,6 @@ afterEach(async () => {
 let aconnDid
 let aconnVerkey
 let aconnUserPwVkey
-
-const msg1Id = uuid.v4()
-const msg2Id = uuid.v4()
-const msg3Id = uuid.v4()
-const msg4Id = uuid.v4()
 
 let agent1Did
 let agent1Verkey

--- a/vcxagency-node/test/unit/messaging/agent-msgs.spec.js
+++ b/vcxagency-node/test/unit/messaging/agent-msgs.spec.js
@@ -70,6 +70,22 @@ let sendToAgency
 let tmpDbData
 let tmpDbWallet
 
+let msg1Id
+let msg2Id
+let msg3Id
+let msg4Id
+let msg5Id
+let msg6Id
+
+function regenerateUuids () {
+  msg1Id = uuid.v4()
+  msg2Id = uuid.v4()
+  msg3Id = uuid.v4()
+  msg4Id = uuid.v4()
+  msg5Id = uuid.v4()
+  msg6Id = uuid.v4()
+}
+
 beforeAll(async () => {
   try {
     jest.setTimeout(1000 * 120)
@@ -106,6 +122,7 @@ afterAll(async () => {
 })
 
 beforeEach(async () => {
+  regenerateUuids()
   {
     agencyUserWalletKey = await indyGenerateWalletKey()
     agencyUserWalletName = `unit-test-${uuid.v4()}`
@@ -177,13 +194,6 @@ afterEach(async () => {
 let aconn1UserPwDid
 let aconn2UserPwDid
 let aconn3UserPwDid
-
-const msg1Id = uuid.v4()
-const msg2Id = uuid.v4()
-const msg3Id = uuid.v4()
-const msg4Id = uuid.v4()
-const msg5Id = uuid.v4()
-const msg6Id = uuid.v4()
 
 let agent1Did
 let agent1Verkey
@@ -356,19 +366,6 @@ describe('onboarding', () => {
     const updateRes = await vcxFlowUpdateMsgsFromAgent(agencyUserWh, sendToAgency, agent1Did, agent1Verkey, agencyUserVerkey, uidsByConn, 'MS-106')
     expect(updateRes['@type']).toBe('did:sov:123456789abcdefghi1234;spec/pairwise/1.0/MSG_STATUS_UPDATED_BY_CONNS')
 
-    expect(updateRes.updatedUidsByConns.length).toBe(2)
-    const updated1 = updateRes.updatedUidsByConns.find(update => update.pairwiseDID === aconn1UserPwDid)
-    const updated2 = updateRes.updatedUidsByConns.find(update => update.pairwiseDID === aconn2UserPwDid)
-
-    expect(updated1).toBeDefined()
-    expect(updated1.uids.length).toBe(2)
-    expect(updated1.uids.includes(msg1Id)).toBeTruthy()
-    expect(updated1.uids.includes(msg2Id)).toBeTruthy()
-
-    expect(updated2).toBeDefined()
-    expect(updated2.uids.length).toBe(1)
-    expect(updated2.uids.includes(msg6Id)).toBeTruthy()
-
     let msgReply = await vcxFlowGetMsgsFromAgent(agencyUserWh, sendToAgency, agent1Did, agent1Verkey, agencyUserVerkey, [aconn1UserPwDid, aconn2UserPwDid], [], [])
     let { msgsByConns } = msgReply
     expect(Array.isArray(msgsByConns)).toBeTruthy()
@@ -414,8 +411,6 @@ describe('onboarding', () => {
     ]
     const updateRes = await vcxFlowUpdateMsgsFromAgent(agencyUserWh, sendToAgency, agent1Did, agent1Verkey, agencyUserVerkey, uidsByConn, 'MS-106')
     expect(updateRes['@type']).toBe('did:sov:123456789abcdefghi1234;spec/pairwise/1.0/MSG_STATUS_UPDATED_BY_CONNS')
-    expect(updateRes.failed.length).toBe(0)
-    expect(updateRes.updatedUidsByConns.length).toBe(0)
   })
 
   function assertMsgsByConHasMessageWithStatus (msgsByConn, msgId, expectedStatusCode) {

--- a/vcxagency-node/test/unit/messaging/agent-msgs.spec.js
+++ b/vcxagency-node/test/unit/messaging/agent-msgs.spec.js
@@ -360,8 +360,8 @@ describe('onboarding', () => {
   it('should update statusCodes of messages', async () => {
     // act
     const uidsByConn = [
-      { pairwiseDID: aconn1UserPwDid, uids: [msg1Id, msg2Id] },
-      { pairwiseDID: aconn2UserPwDid, uids: [msg6Id] }
+      { pairwiseDID: 'not-taken-in-consideration', uids: [msg1Id, msg2Id] },
+      { pairwiseDID: 'not-taken-in-consideration', uids: [msg6Id] }
     ]
     const updateRes = await vcxFlowUpdateMsgsFromAgent(agencyUserWh, sendToAgency, agent1Did, agent1Verkey, agencyUserVerkey, uidsByConn, 'MS-106')
     expect(updateRes['@type']).toBe('did:sov:123456789abcdefghi1234;spec/pairwise/1.0/MSG_STATUS_UPDATED_BY_CONNS')

--- a/vcxagency-node/test/unit/storage/pgstorage-links.spec.js
+++ b/vcxagency-node/test/unit/storage/pgstorage-links.spec.js
@@ -91,42 +91,4 @@ describe('storage', () => {
     const res4 = await storage.aconnLinkPairsByAconnDids(A1, ['12321321312312'])
     expect(res4.length).toBe(0)
   })
-
-  it('should convert uidsByAconnDids to uidsByPwDids', async () => {
-    // arrange
-    const uidsByAconnDids = [{ agentConnDid: A1Conn1, uids: ['foo'] }, { agentConnDid: A1Conn2, uids: ['bar'] }]
-
-    // act
-    const uidsByPwDids = await storage.convertIntoUserUpdateResponse(A1, uidsByAconnDids)
-
-    // assert
-    expect(uidsByPwDids.length).toBe(2)
-
-    const r1 = uidsByPwDids.find(r => r.pairwiseDID === A1Conn1Pw)
-    expect(r1).toBeDefined()
-    expect(r1.uids.includes('foo')).toBeTruthy()
-
-    const r2 = uidsByPwDids.find(r => r.pairwiseDID === A1Conn2Pw)
-    expect(r2).toBeDefined()
-    expect(r2.uids.includes('bar')).toBeTruthy()
-  })
-
-  it('should convert uidsByPwDids to uidsByAconnDids', async () => {
-    // arrange
-    const uidsByAconnDids = [{ pairwiseDID: A1Conn1Pw, uids: ['foo'] }, { pairwiseDID: A1Conn2Pw, uids: ['bar'] }]
-
-    // act
-    const uidsByPwDids = await storage.convertIntoStorageRequest(A1, uidsByAconnDids)
-
-    // assert
-    expect(uidsByPwDids.length).toBe(2)
-
-    const r1 = uidsByPwDids.find(r => r.agentConnDid === A1Conn1)
-    expect(r1).toBeDefined()
-    expect(r1.uids.includes('foo')).toBeTruthy()
-
-    const r2 = uidsByPwDids.find(r => r.agentConnDid === A1Conn2)
-    expect(r2).toBeDefined()
-    expect(r2.uids.includes('bar')).toBeTruthy()
-  })
 })

--- a/vcxagency-node/test/unit/storage/pgstorage-messages-retrieval.spec.js
+++ b/vcxagency-node/test/unit/storage/pgstorage-messages-retrieval.spec.js
@@ -40,6 +40,9 @@ describe('storage', () => {
     const uid1 = uuid.v4()
     const uid2 = uuid.v4()
     const uid3 = uuid.v4()
+    const uid4 = uuid.v4()
+    const uid5 = uuid.v4()
+    const uid6 = uuid.v4()
     const a1Conn1Did = uuid.v4()
     const a1Conn2Did = uuid.v4()
     const a2Conn1Did = uuid.v4()
@@ -51,22 +54,22 @@ describe('storage', () => {
     await storage.storeMessage(agentDid, a1Conn2Did, uid2, 'MS-104', { msg: 'a1hello2' })
     await storage.storeMessage(agentDid, a1Conn2Did, uid3, 'MS-105', { msg: 'a1hello3' })
 
-    await storage.storeMessage(agentDid2, a2Conn1Did, uid1, 'MS-103', { msg: 'a2hello1' })
-    await storage.storeMessage(agentDid2, a2Conn1Did, uid2, 'MS-104', { msg: 'a2hello2' })
-    await storage.storeMessage(agentDid2, a2Conn1Did, uid3, 'MS-105', { msg: 'a2hello3' })
+    await storage.storeMessage(agentDid2, a2Conn1Did, uid4, 'MS-103', { msg: 'a2hello1' })
+    await storage.storeMessage(agentDid2, a2Conn1Did, uid5, 'MS-104', { msg: 'a2hello2' })
+    await storage.storeMessage(agentDid2, a2Conn1Did, uid6, 'MS-105', { msg: 'a2hello3' })
 
     // assert
     const agent2Msgs = await storage.loadMessages(agentDid2, [], [], [])
     expect(agent2Msgs.length).toBe(3)
-    const msg1 = agent2Msgs.find(m => m.metadata.uid === uid1)
+    const msg1 = agent2Msgs.find(m => m.metadata.uid === uid4)
     expect(msg1.metadata.statusCode).toBe('MS-103')
     expect(msg1.payload.msg).toBe('a2hello1')
 
-    const msg2 = agent2Msgs.find(m => m.metadata.uid === uid2)
+    const msg2 = agent2Msgs.find(m => m.metadata.uid === uid5)
     expect(msg2.metadata.statusCode).toBe('MS-104')
     expect(msg2.payload.msg).toBe('a2hello2')
 
-    const msg3 = agent2Msgs.find(m => m.metadata.uid === uid3)
+    const msg3 = agent2Msgs.find(m => m.metadata.uid === uid6)
     expect(msg3.metadata.statusCode).toBe('MS-105')
     expect(msg3.payload.msg).toBe('a2hello3')
   })
@@ -76,6 +79,9 @@ describe('storage', () => {
     const uid2 = uuid.v4()
     const uid3 = uuid.v4()
     const uid4 = uuid.v4()
+    const uid5 = uuid.v4()
+    const uid6 = uuid.v4()
+    const uid7 = uuid.v4()
     const a1Conn1Did = uuid.v4()
     const a1Conn2Did = uuid.v4()
     const a2Conn1Did = uuid.v4()
@@ -89,9 +95,9 @@ describe('storage', () => {
     await storage.storeMessage(agentDid, a1Conn2Did, uid3, 'MS-105', { msg: 'a1hello3' })
     await storage.storeMessage(agentDid, a1Conn3Did, uid4, 'MS-105', { msg: 'a1hello4' })
 
-    await storage.storeMessage(agentDid2, a2Conn1Did, uid1, 'MS-103', { msg: 'a2hello1' })
-    await storage.storeMessage(agentDid2, a2Conn1Did, uid2, 'MS-104', { msg: 'a2hello2' })
-    await storage.storeMessage(agentDid2, a2Conn1Did, uid3, 'MS-105', { msg: 'a2hello3' })
+    await storage.storeMessage(agentDid2, a2Conn1Did, uid5, 'MS-103', { msg: 'a2hello1' })
+    await storage.storeMessage(agentDid2, a2Conn1Did, uid6, 'MS-104', { msg: 'a2hello2' })
+    await storage.storeMessage(agentDid2, a2Conn1Did, uid7, 'MS-105', { msg: 'a2hello3' })
 
     // assert
     const msgObjects = await storage.loadMessages(agentDid, [a1Conn1Did, a1Conn3Did], [], [])
@@ -104,6 +110,9 @@ describe('storage', () => {
     const uid1 = uuid.v4()
     const uid2 = uuid.v4()
     const uid3 = uuid.v4()
+    const uid4 = uuid.v4()
+    const uid5 = uuid.v4()
+    const uid6 = uuid.v4()
     const a1Conn1Did = uuid.v4()
     const a2Conn1Did = uuid.v4()
     const agentDid = uuid.v4()
@@ -114,9 +123,9 @@ describe('storage', () => {
     await storage.storeMessage(agentDid, a1Conn1Did, uid2, 'MS-104', { msg: 'msg2' })
     await storage.storeMessage(agentDid, a1Conn1Did, uid3, 'MS-105', { msg: 'msg3' })
 
-    await storage.storeMessage(agentDid2, a2Conn1Did, uid1, 'MS-103', { msg: 'xxxxxxx1' })
-    await storage.storeMessage(agentDid2, a2Conn1Did, uid2, 'MS-104', { msg: 'xxxxxxx2' })
-    await storage.storeMessage(agentDid2, a2Conn1Did, uid3, 'MS-105', { msg: 'xxxxxxx3' })
+    await storage.storeMessage(agentDid2, a2Conn1Did, uid4, 'MS-103', { msg: 'xxxxxxx1' })
+    await storage.storeMessage(agentDid2, a2Conn1Did, uid5, 'MS-104', { msg: 'xxxxxxx2' })
+    await storage.storeMessage(agentDid2, a2Conn1Did, uid6, 'MS-105', { msg: 'xxxxxxx3' })
 
     // assert
     const msgObjects = await storage.loadMessages(agentDid, [], [uid1, uid3], [])
@@ -131,6 +140,9 @@ describe('storage', () => {
     const uid1 = uuid.v4()
     const uid2 = uuid.v4()
     const uid3 = uuid.v4()
+    const uid4 = uuid.v4()
+    const uid5 = uuid.v4()
+    const uid6 = uuid.v4()
     const a1Conn1Did = uuid.v4()
     const a2Conn1Did = uuid.v4()
     const agentDid = uuid.v4()
@@ -141,9 +153,9 @@ describe('storage', () => {
     await storage.storeMessage(agentDid, a1Conn1Did, uid2, 'MS-104', { msg: 'msg2' })
     await storage.storeMessage(agentDid, a1Conn1Did, uid3, 'MS-105', { msg: 'msg3' })
 
-    await storage.storeMessage(agentDid2, a2Conn1Did, uid1, 'MS-103', { msg: 'xxxxxxx1' })
-    await storage.storeMessage(agentDid2, a2Conn1Did, uid2, 'MS-104', { msg: 'xxxxxxx2' })
-    await storage.storeMessage(agentDid2, a2Conn1Did, uid3, 'MS-105', { msg: 'xxxxxxx3' })
+    await storage.storeMessage(agentDid2, a2Conn1Did, uid4, 'MS-103', { msg: 'xxxxxxx1' })
+    await storage.storeMessage(agentDid2, a2Conn1Did, uid5, 'MS-104', { msg: 'xxxxxxx2' })
+    await storage.storeMessage(agentDid2, a2Conn1Did, uid6, 'MS-105', { msg: 'xxxxxxx3' })
 
     // assert
     const msgObjects = await storage.loadMessages(agentDid, [], [], ['MS-105'])
@@ -159,6 +171,12 @@ describe('storage', () => {
     const uid5 = uuid.v4()
     const uid6 = uuid.v4()
     const uid7 = uuid.v4()
+    const uid8 = uuid.v4()
+    const uid9 = uuid.v4()
+    const uid10 = uuid.v4()
+    const uid11 = uuid.v4()
+    const uid12 = uuid.v4()
+    const uid13 = uuid.v4()
     const a1Conn1Did = uuid.v4()
     const a1Conn2Did = uuid.v4()
     const a2Conn1Did = uuid.v4()
@@ -178,12 +196,12 @@ describe('storage', () => {
     await storage.storeMessage(agentDid, a1Conn2Did, uid7, 'MS-105', { msg: 'msg6' })
 
     // agent2
-    await storage.storeMessage(agentDid2, a2Conn1Did, uid1, 'MS-103', { msg: 'xxxxxxx1' })
-    await storage.storeMessage(agentDid2, a2Conn1Did, uid2, 'MS-104', { msg: 'xxxxxxx2' })
-    await storage.storeMessage(agentDid2, a2Conn1Did, uid3, 'MS-105', { msg: 'xxxxxxx3' })
-    await storage.storeMessage(agentDid2, a2Conn1Did, uid4, 'MS-103', { msg: 'xxxxxxx1' })
-    await storage.storeMessage(agentDid2, a2Conn1Did, uid5, 'MS-104', { msg: 'xxxxxxx2' })
-    await storage.storeMessage(agentDid2, a2Conn1Did, uid6, 'MS-105', { msg: 'xxxxxxx3' })
+    await storage.storeMessage(agentDid2, a2Conn1Did, uid8, 'MS-103', { msg: 'xxxxxxx1' })
+    await storage.storeMessage(agentDid2, a2Conn1Did, uid9, 'MS-104', { msg: 'xxxxxxx2' })
+    await storage.storeMessage(agentDid2, a2Conn1Did, uid10, 'MS-105', { msg: 'xxxxxxx3' })
+    await storage.storeMessage(agentDid2, a2Conn1Did, uid11, 'MS-103', { msg: 'xxxxxxx1' })
+    await storage.storeMessage(agentDid2, a2Conn1Did, uid12, 'MS-104', { msg: 'xxxxxxx2' })
+    await storage.storeMessage(agentDid2, a2Conn1Did, uid13, 'MS-105', { msg: 'xxxxxxx3' })
 
     // assert
     const res1 = await storage.loadMessages(agentDid, [a1Conn1Did], [uid1], ['MS-103'])

--- a/vcxagency-node/test/unit/storage/pgstorage-messages-update.spec.js
+++ b/vcxagency-node/test/unit/storage/pgstorage-messages-update.spec.js
@@ -54,17 +54,9 @@ describe('storage', () => {
     await storage.storeMessage(agentDid, agentConn2Did, uid4, 'MS-105', { msg: 'hello4' })
 
     // act
-    const { failed, updated } =
-      await storage.updateStatusCodes(agentDid, [{ agentConnDid: agentConn2Did, uids: [uid2, uid4] }], 'MS-106')
+    await storage.updateStatusCodeAgentConnection(agentDid, [uid2, uid4], 'MS-106')
 
     // assert
-    expect(failed.length).toBe(0)
-    expect(updated.length).toBe(1)
-    expect(updated[0].agentConnDid).toBe(agentConn2Did)
-    expect(updated[0].uids.length).toBe(2)
-    expect(updated[0].uids.find(uid => uid === uid2)).toBeDefined()
-    expect(updated[0].uids.find(uid => uid === uid4)).toBeDefined()
-
     const msgObjects = await storage.loadMessages(agentDid, agentConn2Did, [], [])
     expect(msgObjects.length).toBe(3)
     const msg2 = msgObjects.find(m => m.metadata.uid === uid2)
@@ -93,11 +85,10 @@ describe('storage', () => {
     await storage.storeMessage(agentDid, agentConn2Did, uid4, 'MS-105', { msg: 'hello4' })
 
     // act
-    const { failed, updated } =
-      await storage.updateStatusCodes(agentDid, [{ agentConnDid: agentConn2Did, uids: [] }], 'MS-106')
+    await storage.updateStatusCodeAgentConnection(agentDid, [], 'MS-106')
 
     // assert
-    expect(failed.length).toBe(0)
-    expect(updated.length).toBe(0)
+    const msgObjects = await storage.loadMessages(agentDid, [agentConn1Did, agentConn2Did], agentConn2Did, [], ['MS-106'])
+    expect(msgObjects.length).toBe(0)
   })
 })


### PR DESCRIPTION
Currently, message handling of type `UPDATE_MSG_STATUS_BY_CONNS` is highly inefficient. It takes a list of pairs of  `pwDids` of the agent connection corresponding to the message to be updated and a list of uids of the messages to be updated (along with the status code to be assigned):
```
[{"pairwiseDID":"Fp4eVWcjyRawjNWgnJmJWD","uids":["b7vh36XiTe"]}]
```

In order to perform the update, this argument is converted to a format such that each agent connection `pwDid` is converted to an agent connection did, querying the database potentially multiple times in the process.

Moreover, in order to construct the response containing updated and failed-to-update lists of pairs in the same format described above, it performs an inverse conversion using the same inefficient method described above.

This PR optimizes this behavior in a weakly backwards-compatible fashion by ensuring global uniqueness of message uids on the database level (by using UNIQUE constraint), merging all the uids in the received messages and performing a single query on indexed columns `agent_did` and `uid` on the `messages` table.

Signed-off-by: Miroslav Kovar <miroslav.kovar@absa.africa>