### PR TITLE
Support aries @type prefixed https://didcomm.org/

### DIFF
--- a/vcxagency-client/src/messaging/aries/aries-msg.js
+++ b/vcxagency-client/src/messaging/aries/aries-msg.js
@@ -16,8 +16,11 @@
 
 'use strict'
 
-const MSGTYPE_ARIES_FWD = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/routing/1.0/forward'
-const MSGTYPE_ARIES_BASIC_MSG = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0/message'
+const MSGTYPE_ARIES_FWD_LEGACY = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/routing/1.0/forward'
+const MSGTYPE_ARIES_BASIC_MSG_LEGACY = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0/message'
+
+const MSGTYPE_ARIES_FWD = 'https://didcomm.org/routing/1.0/forward'
+const MSGTYPE_ARIES_BASIC_MSG = 'https://didcomm.org/basicmessage/1.0/message'
 
 function buildAriesFwdMessage (to, msgObject) {
   const msg = {
@@ -42,6 +45,8 @@ function buildAriesBasicMessage (id, msgString, sentUtime = '2019-01-15 18:42:01
 module.exports = {
   buildAriesFwdMessage,
   buildAriesBasicMessage,
+  MSGTYPE_ARIES_FWD_LEGACY,
+  MSGTYPE_ARIES_BASIC_MSG_LEGACY,
   MSGTYPE_ARIES_FWD,
   MSGTYPE_ARIES_BASIC_MSG
 }

--- a/vcxagency-node/src/service/entities/agent-connection/agent-connection.js
+++ b/vcxagency-node/src/service/entities/agent-connection/agent-connection.js
@@ -17,11 +17,11 @@
 'use strict'
 
 const {
-  MSGTYPE_ARIES_FWD,
+  MSGTYPE_ARIES_FWD_LEGACY,
   MSGTYPE_GET_MSGS,
   MSGTYPE_MSGS,
   tryParseAuthcrypted,
-  buildMsgVcxV2Msgs
+  buildMsgVcxV2Msgs, MSGTYPE_ARIES_FWD
 } = require('vcxagency-client')
 const { pack } = require('easy-indysdk')
 const { objectToBuffer, timeOperation } = require('../../util')
@@ -132,7 +132,7 @@ async function buildAgentConnectionAO (entityRecord, serviceWallets, serviceStor
 
   async function _handleDecryptedMsg (msgObject, senderVerkey) {
     const msgType = msgObject['@type']
-    if (msgType === MSGTYPE_ARIES_FWD) {
+    if (msgType === MSGTYPE_ARIES_FWD || msgType === MSGTYPE_ARIES_FWD_LEGACY) {
       await _handleAriesFwd(msgObject)
       return { response: '', shouldEncrypt: false }
     } else {

--- a/vcxagency-node/src/service/entities/fwa/entity-fwa.js
+++ b/vcxagency-node/src/service/entities/fwa/entity-fwa.js
@@ -19,6 +19,7 @@
 const {
   MSG_TYPE_AGENCY_FWD,
   MSGTYPE_ARIES_FWD,
+  MSGTYPE_ARIES_FWD_LEGACY,
   parseAuthcrypted,
   parseAnoncrypted,
   buildMsgVcxV2Connected
@@ -145,7 +146,7 @@ async function buildForwardAgent (serviceIndyWallets, serviceStorage, agencyWall
       if (msgType === MSG_TYPE_AGENCY_FWD) {
         logger.info(`${whoami} Received message of msgType=${msgType}`)
         return await processMsgVcxV2Fwd(message)
-      } else if (msgType === MSGTYPE_ARIES_FWD) {
+      } else if (msgType === MSGTYPE_ARIES_FWD || msgType === MSGTYPE_ARIES_FWD_LEGACY) {
         logger.info(`${whoami} Received message of msgType=${msgType}`)
         return await processMsgAriesFwd(message)
       } else {

--- a/vcxagency-node/test/unit/messaging/aries-msgs.spec.js
+++ b/vcxagency-node/test/unit/messaging/aries-msgs.spec.js
@@ -169,7 +169,7 @@ describe('onboarding', () => {
     const { message, sender_verkey: senderVerkey } = await unpack(aliceWh, objectToBuffer(msgs[0].payload))
     expect(senderVerkey).toBe(bobToAliceVerkey)
     const messageObject = JSON.parse(message)
-    expect(messageObject['@type']).toBe('did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0/message')
+    expect(messageObject['@type']).toBe('https://didcomm.org/basicmessage/1.0/message')
     expect(messageObject.sent_time).toBe('2019-01-15 18:42:01Z')
     expect(messageObject.content).toBe('This is Bob!')
   })


### PR DESCRIPTION
Support `https://didcomm.org` prefixed `@type` on aries routing messags.

Signed-off-by: Patrik Stas <patrik.stas@absa.africa>